### PR TITLE
Filter Home Page on Tag "Socialism"

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,7 +5,8 @@ title = "BreadTube.tv"
 # https://fontawesome.com/v4.7.0/cheatsheet/
 
 [ params ]
-OpenLinksInNewWindow = true
+targetBlank = true
+defaultTags = []
 
 [[ params.nav ]]
 name = "Reddit"

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,3 +1,4 @@
 ---
 title: BreadTube.tv
+tags: [socialism]
 ---

--- a/data/links.yml
+++ b/data/links.yml
@@ -28,25 +28,25 @@ tiles:
   slug: "contrapoints"
   url: "https://www.youtube.com/contrapoints"
   subscribers: 399836
-  tags: []
+  tags: ["socialism"]
 -
   name: "hbomberguy"
   slug: "hbomberguy"
   url: "https://www.youtube.com/hbomberguy"
   subscribers: 325262
-  tags: []
+  tags: ["socialism"]
 -
   name: "Philsophy Tube"
   slug: "thephilosophytube"
   url: "https://www.youtube.com/thephilosophytube"
   subscribers: 295581
-  tags: []
+  tags: ["socialism"]
 -
   name: "Peter Coffin"
   slug: "petercoffin"
   url: "https://www.youtube.com/petercoffin"
   subscribers: 236769
-  tags: []
+  tags: ["socialism"]
 -
   name: "friendlyjordies"
   slug: "friendlyjordies"
@@ -58,13 +58,13 @@ tiles:
   slug: "threearrows"
   url: "https://www.youtube.com/threearrows"
   subscribers: 180487
-  tags: []
+  tags: ["socialism"]
 -
   name: "Shaun"
   slug: "shaun"
   url: "https://www.youtube.com/channel/UCJ6o36XL0CpYb6U5dNBiXHQ"
   subscribers: 180487
-  tags: []
+  tags: ["socialism"]
 -
   name: "The Juice Media"
   slug: "thejuicemedia"
@@ -88,59 +88,59 @@ tiles:
   slug: "democracyatwrk"
   url: "https://www.youtube.com/democracyatwrk"
   subscribers: 73439
-  tags: []
+  tags: ["socialism"]
 -
   name: "BadMouse Productions"
   slug: "xaxie1"
   url: "https://www.youtube.com/xaxie1"
   subscribers: 49927
-  tags: []
+  tags: ["socialism"]
 -
   name: "Zero Books"
   slug: "zerobooks"
   url: "https://www.youtube.com/channel/UCyoQK-mZXr2ws4C0nXGCH1w"
   subscribers: 36622
-  tags: []
+  tags: ["socialism"]
 -
   name: "Mexie"
   slug: "mexie"
   url: "https://www.youtube.com/Mexie"
   subscribers: 26058
-  tags: []
+  tags: ["socialism"]
 -
   name: "Thought Slime"
   slug: "thoughtslime"
   url: "https://www.youtube.com/thoughtslime"
   subscribers: 19904
-  tags: []
+  tags: ["socialism"]
 -
   name: "NonCompete"
   slug: "noncompete"
   url: "https://www.youtube.com/noncompete"
   subscribers: 19276
-  tags: []
+  tags: ["socialism"]
 -
   name: "Radical Reviewer"
   slug: "radicalreviewer"
   url: "https://www.youtube.com/radicalreviewer"
   subscribers: 2805
-  tags: []
+  tags: ["socialism"]
 -
   name: "Kenny Logan"
   slug: "ploppy111"
   url: "https://www.youtube.com/ploppy111"
   subscribers: 10303
-  tags: []
+  tags: ["socialism"]
 -
   name: "Angie Speaks"
   slug: "angiespeaks"
   url: "https://www.youtube.com/channel/UCUtloyZ_Iu4BJekIqPLc_fQ"
   subscribers: 8367
-  tags: []
+  tags: ["socialism"]
 -
   name: "Erin Collective"
   slug: "erincollective"
   url: "https://www.youtube.com/erincollective"
   subscribers: 515
-  tags: []
+  tags: ["socialism"]
 

--- a/layouts/partials/tile_slate.html
+++ b/layouts/partials/tile_slate.html
@@ -1,6 +1,9 @@
 <div class="d-flex flex-wrap">
-  {{$jump := .Site.Params.OpenLinksInNewWindow | default true }}
+  {{ $jump := .Site.Params.targetBlank | default true }}
+  {{ $tags := .Params.tags | default .Site.Params.defaultTags }}
   {{ range .Site.Data.links.tiles }}
-    {{ partial "tile.html" (dict "Link" . "Jump" $jump)}}
+    {{ if or (eq (len $tags) 0) (intersect $tags .tags) }}
+      {{ partial "tile.html" (dict "Link" . "Jump" $jump) }}
+    {{ end }}
   {{ end }}
 </div>


### PR DESCRIPTION
https://deploy-preview-3--breadtubetv.netlify.com/

This just cuts down on the amount of home page items for a bit while we try to figure out what is we show, really keeping it to the BreadTube community.

It also adds a configuration which would mean we could create sub category pages, this feature could also become more javascript based in the future.

A good piece of research would be pulling all the channels that have been linked in https://reddit.com/r/breadtube.