### PR TITLE
Providers Data Structure. Patreon & YouTube

### DIFF
--- a/data/channels/anactualjoke.yml
+++ b/data/channels/anactualjoke.yml
@@ -1,6 +1,13 @@
-name: "anactualjoke"
+name: "AnActualJoke"
 slug: "anactualjoke"
-url: "https://www.youtube.com/channel/UC-CDQ-MPUdBWcjB7SrD1HZA"
 description: Anarchist Trans Girl. She/Her. Making Video Essays and hot takes
-subscribers: 8603
+providers:
+  youtube:
+    name: "anactualjoke"
+    url: "https://www.youtube.com/channel/UC-CDQ-MPUdBWcjB7SrD1HZA"
+    subscribers: 8603
+  patreon:
+    name: "AnActualJoke"
+    url: "https://www.patreon.com/anactualjoke"
+    decription: "Video Essays"
 tags: ["breadtube"]

--- a/data/channels/anarchopac.yml
+++ b/data/channels/anarchopac.yml
@@ -1,6 +1,15 @@
 name: "anarchopac"
 slug: "anarchopac"
-url: "https://www.youtube.com/user/anarchopac"
 description: "I'm a disabled pan-sexual trans woman who talks about anarchism, feminism and marxism."
-subscribers: 15438
+subscribers:
+providers:
+  youtube:
+    name: "anarchopac"
+    url: "https://www.youtube.com/user/anarchopac"
+    subscribers: 15438
+    description: ""
+  patreon:
+    name: "anarchopac"
+    url: "https://www.patreon.com/anarchopac"
+    description: "left-wing youtube videos"
 tags: ["breadtube"]

--- a/layouts/partials/channels/card.html
+++ b/layouts/partials/channels/card.html
@@ -1,5 +1,5 @@
 <div class="card-column col-12 col-sm-6 col-md-4 col-lg-3 col-xl mb-3 pl-2 pr-2 d-flex">
-  <a href="{{ .channel.url }}" target="_blank" class="card card-channel flex-fill">
+  <a href="{{ or .channel.providers.youtube.url .channel.url }}" target="_blank" class="card card-channel flex-fill">
     <img src="/img/channels/{{ .channel.slug }}.jpg" class="img-video card-img-top" src="https://i3.ytimg.com/vi/{{ .video.id }}/hqdefault.jpg" /c>
     <div class="card-body pt-1 pb-1 pl-2 pr-1">
       {{ if .channel.subscribers }}


### PR DESCRIPTION
Adds support for the upgrade path of providers with additional `providers` information, include YouTube and Patreon (this will be a huge support for people, doesn't need an API atm).

This is meant to be safe to merge as is, providing an upgrade path which could likely be solved by the [`bake channel import` yaml formatting PR#54](https://github.com/breadtubetv/breadtubetv/pull/54).