### PR TITLE
list item padding on mobile

### DIFF
--- a/static/css/breadtube.css
+++ b/static/css/breadtube.css
@@ -309,12 +309,13 @@ button, select, input, textarea { font-family: inherit; }
 }
 
 .list > li {
-  padding: 0 0 2rem 1rem;
+  padding: 0 1rem 2rem 1rem;
 }
 
 @media (min-width: 768px) {
   .list > li {
     flex-basis: 25%;
+    padding: 0 0 2rem 1rem;
   }
 }
 


### PR DESCRIPTION
Flushed up against side

<img width="335" alt="screen shot 2019-03-06 at 7 06 10 pm" src="https://user-images.githubusercontent.com/81055/53922588-f5f4ef80-4042-11e9-921c-8c3e5be9ce27.png">

Fixed (not flushed)

<img width="330" alt="screen shot 2019-03-06 at 7 06 15 pm" src="https://user-images.githubusercontent.com/81055/53922610-0e650a00-4043-11e9-8240-be5c56615ff2.png">

Used a bad example because of the title wrap