### PR TITLE
Manifest Update

### DIFF
--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -1,6 +1,6 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "BreadTube",
+    "short_name": "BreadTube",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",
@@ -15,5 +15,5 @@
     ],
     "theme_color": "#ffffff",
     "background_color": "#ffffff",
-    "display": "standalone"
+    "display": "browser"
 }


### PR DESCRIPTION
This improves the Progressive Web App experience by

- Setting an application name
- Displaying as a browser
  - Users can share urls
  - Users can go back and forth

### Now

(url will say https://breadtube.tv/)

![Updated Manifest](https://user-images.githubusercontent.com/81055/55292674-c6c06c80-53bb-11e9-933d-4fab9e633b6f.png)

### Previously

![Old Manifest](https://user-images.githubusercontent.com/81055/55292669-b90ae700-53bb-11e9-9796-bbe5d88b6dc6.png)
