### PR TITLE
Sort Channels By Slug

### DIFF
--- a/layouts/partials/channels/row.html
+++ b/layouts/partials/channels/row.html
@@ -2,7 +2,7 @@
 <ul class="list plain-list">
   {{ $jump := .Site.Params.targetBlank | default true }}
   {{ $tags := .Params.tags | default .Site.Params.defaultTags }}
-  {{ range sort .Site.Data.channels "name" "asc" }}
+  {{ range sort .Site.Data.channels "slug" "asc" }}
     {{ if or (eq (len $tags) 0) (intersect $tags .tags) }}
       {{ partial "channels/card.html" (dict "channel" . "target_blank" $jump) }}
     {{ end }}


### PR DESCRIPTION
Uses the slug attribute which is downcase to sort, instead of name.

Fixes a serious issues where channels were listed based on case sensitivity, meaning that channels starting with a lower case "a" were after those with an upper case "Z" 