### PR TITLE
Allow config of channels dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,53 @@ open localhost:1313
 
 ## [Contributing](https://github.com/breadtubetv/breadtubetv/blob/master/CONTRIBUTING.md)
 
+### Configuring the `bake` CLI
+
+The `.bake.yaml` configuration file can be stored in the following locations:
+
+- `$HOME/.bake.yaml`
+- `./bake.yaml` (In other words, the current directory from which you're running the CLI)
+
+Current configuration options and default values:
+
+- `channelsDir: "../data/channels"` : Set to the location of the `channels` directory under the `data` directory. E.g. `$GOPATH/src/github.com/breadtubetv/breadtubetv`
+
 ### Adding a Channel
 
-#### [Walkthrough Video](https://youtu.be/jpOun7YXFpg)
+#### [Walkthrough Video](https://youtu.be/jpOun7YXFpg) (Out of date)
 
-- Edit [`data/channels.yml`](https://github.com/breadtubetv/breadtubetv/blob/master/data/channels.yml)
-- Put the channel information in (order by subscribers)
+You can use the `bake` CLI, instructions [here](#Importing-a-Channel) to add channels OR
+
+- Create a `<channelName>.yaml` file in [`data/channels/`](https://github.com/breadtubetv/breadtubetv/blob/master/data/channels)
+- Fill in the required information:
+  ```yaml
+    name: Readable Name
+    permalink: <slug>
+    providers:
+      twitter:
+        name: Readable Name
+        slug: username
+        url: https://www.twitter.com/<username>
+      youtube:
+        name: Readable Name
+        slug: youtube-id
+        url: https://www.youtube.com/channel/<youtube-id>
+        subscribers: 9000
+    slug: <slug>
+    tags:
+    - breadtube
+  ```
+- Create a `<channelName>.md` file in [`content`](https://github.com/breadtubetv/breadtubetv/blob/master/content)
+- Follow this example format:
+  ```
+  ---
+  title: "<Readable Name>"
+  type: "channels"
+  channel: "<slug>"
+  menu:
+    main:
+      parent: "Channels"
+  ---
 - Download the image and save it to [`static/img/channels/`](https://github.com/breadtubetv/breadtubetv/blob/master/static/img/channels)
 
 ### Creating a Playlist

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ The `.bake.yaml` configuration file can be stored in the following locations:
 
 Current configuration options and default values:
 
-- `channelsDir: "../data/channels"` : Set to the location of the `channels` directory under the `data` directory. E.g. `$GOPATH/src/github.com/breadtubetv/breadtubetv`
+- `projectRoot: "../"` : Directory of channel data files.    
+  E.g. `$GOPATH/src/github.com/breadtubetv/breadtubetv/data/channels`
 
 ### Adding a Channel
 

--- a/bake/cmd/import.go
+++ b/bake/cmd/import.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/breadtubetv/breadtubetv/bake/util"
@@ -22,7 +23,7 @@ var importCmd = &cobra.Command{
 		var slug = args[0]
 		var provider = args[1]
 		var channelURL, err = util.ParseURL(args[2])
-		dataDir := viper.GetString("channelsDir")
+		dataDir := os.ExpandEnv(viper.GetString("channelsDir"))
 
 		if err != nil {
 			log.Fatalf("Improperly formatted URL provided '%s': %v", args[1], err)

--- a/bake/cmd/import.go
+++ b/bake/cmd/import.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/breadtubetv/breadtubetv/bake/util"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // importCmd represents the import command
@@ -14,13 +15,14 @@ var importCmd = &cobra.Command{
 	Use:   "import <slug> <provider> <channel_url>",
 	Short: "Import a channel into BreadtubeTV",
 	Long: fmt.Sprintf(`Add the supplied channel into BreadtubeTV, without having to edit JSON.
-	
+
 	Available providers: %s`, strings.Join(ProviderNames(), ", ")),
 	Args: cobra.ExactArgs(3),
 	Run: func(cmd *cobra.Command, args []string) {
 		var slug = args[0]
 		var provider = args[1]
 		var channelURL, err = util.ParseURL(args[2])
+		dataDir := viper.GetString("channelsDir")
 
 		if err != nil {
 			log.Fatalf("Improperly formatted URL provided '%s': %v", args[1], err)
@@ -31,7 +33,7 @@ var importCmd = &cobra.Command{
 		}
 
 		log.Printf("Importing %s...\n", channelURL)
-		Providers[provider]["channel_import"].(func(string, *util.URL))(slug, channelURL)
+		Providers[provider]["channel_import"].(func(string, *util.URL, string))(slug, channelURL, dataDir)
 	},
 }
 

--- a/bake/cmd/import.go
+++ b/bake/cmd/import.go
@@ -23,7 +23,7 @@ var importCmd = &cobra.Command{
 		var slug = args[0]
 		var provider = args[1]
 		var channelURL, err = util.ParseURL(args[2])
-		dataDir := os.ExpandEnv(viper.GetString("channelsDir"))
+		dataDir := fmt.Sprintf("%s/data/channels", os.ExpandEnv(viper.GetString("projectRoot")))
 
 		if err != nil {
 			log.Fatalf("Improperly formatted URL provided '%s': %v", args[1], err)

--- a/bake/cmd/root.go
+++ b/bake/cmd/root.go
@@ -13,11 +13,8 @@ import (
 
 var cfgFile string
 
-/*
-	This map is set up so that we can call functions dynamically for providers.
-
-	e.g. Providers["youtube"]["config"].(func(string))("somestring")
-*/
+//Providers is a map setup so that we can call functions dynamically for providers.
+// e.g. Providers["youtube"]["config"].(func(string))("somestring")
 var Providers = map[string]map[string]interface{}{
 	"youtube": providers.LoadYoutube(),
 }
@@ -35,7 +32,7 @@ var rootCmd = &cobra.Command{
 	Use:   "bake",
 	Short: "Manage BreadtubeTV content.",
 	Long: `Bake can be used to manage the content available in BreadtubeTV.
-	
+
 	You can add channels, playlists, videos and courses without having to edit data directly.
 	`}
 
@@ -59,6 +56,10 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
+
+	viper.SetDefault("channelsDir", "../data/channels")
+	viper.SetDefault("channelPagesDir", "../content")
+
 	if cfgFile != "" {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
@@ -71,10 +72,11 @@ func initConfig() {
 		}
 
 		// Search config in home directory with name ".bake" (without extension).
+		viper.AddConfigPath(".")
 		viper.AddConfigPath(home)
 		viper.SetConfigName(".bake")
 	}
-
+	viper.SetEnvPrefix("bake")
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.

--- a/bake/cmd/root.go
+++ b/bake/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/breadtubetv/breadtubetv/bake/providers"
 
@@ -57,8 +58,10 @@ func init() {
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
 
-	viper.SetDefault("channelsDir", "../data/channels")
-	viper.SetDefault("channelPagesDir", "../content")
+	wd, _ := os.Getwd()
+	// filepath.Dir(wd) will get the parent dir of the current working dir
+	// This is the equivalent of `..`
+	viper.SetDefault("projectRoot", filepath.Dir(wd))
 
 	if cfgFile != "" {
 		// Use config file from the flag.

--- a/bake/providers/youtube.go
+++ b/bake/providers/youtube.go
@@ -105,8 +105,8 @@ func formatChannelDetails(slug string, channelURL *util.URL) (util.Channel, erro
 	}, nil
 }
 
-func importChannel(slug string, channelURL *util.URL) {
-	channelList := util.LoadChannels("../data/channels")
+func importChannel(slug string, channelURL *util.URL, dataDir string) {
+	channelList := util.LoadChannels(dataDir)
 
 	importedChannel, err := formatChannelDetails(slug, channelURL)
 	if err != nil {
@@ -123,7 +123,7 @@ func importChannel(slug string, channelURL *util.URL) {
 
 	log.Printf("Title: %s, Count: %d\n", channel.Name, channel.Providers["youtube"].Subscribers)
 
-	err = util.SaveChannel(channel, "../data/channels")
+	err = util.SaveChannel(channel, dataDir)
 	if err != nil {
 		log.Fatalf("Error saving channel '%s': %v", slug, err)
 	}


### PR DESCRIPTION
This PR addresses one aspect of #171 - it allows the user to set the path of the channels dir, rather than having to be within the `$repo/bake` directory.