### PR TITLE
Fix PushState issue with URL

### DIFF
--- a/layouts/partials/search/bar.html
+++ b/layouts/partials/search/bar.html
@@ -1,4 +1,4 @@
 <div>
   <label for="search" class="visually-hidden">Search Channels</label>
-  <input id="search" type="search" placeholder="Search Channels" class="header-search" autofocus />
+  <input id="search" type="search" placeholder="Search Channels" class="header-search" />
 </div>

--- a/layouts/partials/search/code.html
+++ b/layouts/partials/search/code.html
@@ -27,26 +27,41 @@ var list = document.getElementsByClassName("list")[0];
 var items = list.children;
 
 function listSearch(query) {
-  list.classList.toggle('searching', query.length > 0);
-
-  window.location.hash = 'search:' + query.toLowerCase();;
+  var baseUrl = window.location.href;
+  var search = document.getElementById("search");
   var results = fuse.search(query);
+
+  list.classList.toggle('searching', query.length > 0);
   for (var i = 0; i < items.length; i++) {
     var item = items[i];
     item.classList.toggle('found', results.indexOf(item.id) > -1);
   }
+}
 
-  if(search.value.length == 0) {
+function setSearch(query) {
+  if(query && query.length > 0) {
     search.value = query.replace("%20"," ");
+    listSearch(query);
   }
 }
 
 search.addEventListener("keyup", function() {
   var query = this.value;
   listSearch(query);
+
+  history.replaceState(window.history.state,{},'?q=' + query.toLowerCase());
 });
 
-if(window.location.hash && window.location.hash.indexOf('search') > -1) {
-  listSearch(window.location.hash.replace("#search:",""));
-}
+window.addEventListener("DOMContentLoaded", function(e) {
+  let searchParams = new URLSearchParams(window.location.search);
+  let query = searchParams.get('q');
+
+  setSearch(query);
+});
+
+// An autoload hack for the search box
+window.addEventListener("load", function(e) {
+  search.focus();
+  search.value = search.value;
+});
 </script>

--- a/layouts/partials/search/code.html
+++ b/layouts/partials/search/code.html
@@ -57,10 +57,7 @@ window.addEventListener("DOMContentLoaded", function(e) {
   let query = searchParams.get('q');
 
   setSearch(query);
-});
 
-// An autoload hack for the search box
-window.addEventListener("load", function(e) {
   search.focus();
   search.value = search.value;
 });

--- a/layouts/partials/search/code.html
+++ b/layouts/partials/search/code.html
@@ -61,4 +61,13 @@ window.addEventListener("DOMContentLoaded", function(e) {
   search.focus();
   search.value = search.value;
 });
+
+search.addEventListener("search", function(e) {
+  list.classList.toggle('searching');
+  for (var i = 0; i < items.length; i++) {
+    var item = items[i];
+    item.classList.remove("found");
+  }
+  window.location.href = window.location.origin;
+})
 </script>


### PR DESCRIPTION
Fixes #173 by using `replaceState` instead of `window.location`

## Reproduce

- Visit https://breadtube.tv
- Search for `contrapo`
- Click `back`
- You should be on https://breadtube.tv/#search:contrap
- click `Contrapoints`
- Click `back`
- You should be on https://breadtube.tv/#search:contrap
- Click `back`
- You should be on https://breadtube.tv/#search:contra

## Acceptance

- Visit https://deploy-preview-184--breadtubetv.netlify.com/
- Search for `contrapo`
- You should be on `null`
- Click `forward`
- You should be on  https://deploy-preview-184--breadtubetv.netlify.com/
- Search for `contrapo`
- Click `Contrapoints`
- Click `back`
- You should be on https://deploy-preview-184--breadtubetv.netlify.com/#search:contrap
- Click `back`
- You should be on `null`

Upgrades the search to be query param based instead of hash based.

https://deploy-preview-184--breadtubetv.netlify.com/?q=contrap

## Questions

- Should we retain the hash based urls?