### PR TITLE
Bake CLI - Create Channel Pages

### DIFF
--- a/bake/cmd/import.go
+++ b/bake/cmd/import.go
@@ -23,7 +23,7 @@ var importCmd = &cobra.Command{
 		var slug = args[0]
 		var provider = args[1]
 		var channelURL, err = util.ParseURL(args[2])
-		dataDir := fmt.Sprintf("%s/data/channels", os.ExpandEnv(viper.GetString("projectRoot")))
+		projectRoot := os.ExpandEnv(viper.GetString("projectRoot"))
 
 		if err != nil {
 			log.Fatalf("Improperly formatted URL provided '%s': %v", args[1], err)
@@ -34,7 +34,7 @@ var importCmd = &cobra.Command{
 		}
 
 		log.Printf("Importing %s...\n", channelURL)
-		Providers[provider]["channel_import"].(func(string, *util.URL, string))(slug, channelURL, dataDir)
+		Providers[provider]["channel_import"].(func(string, *util.URL, string))(slug, channelURL, projectRoot)
 	},
 }
 

--- a/bake/providers/youtube.go
+++ b/bake/providers/youtube.go
@@ -105,7 +105,8 @@ func formatChannelDetails(slug string, channelURL *util.URL) (util.Channel, erro
 	}, nil
 }
 
-func importChannel(slug string, channelURL *util.URL, dataDir string) {
+func importChannel(slug string, channelURL *util.URL, projectRoot string) {
+	dataDir := path.Join(projectRoot, "/data/channels")
 	channelList := util.LoadChannels(dataDir)
 
 	importedChannel, err := formatChannelDetails(slug, channelURL)
@@ -119,6 +120,7 @@ func importChannel(slug string, channelURL *util.URL, dataDir string) {
 	}
 	channel.Name = importedChannel.Name
 	channel.Slug = importedChannel.Slug
+	channel.Permalink = importedChannel.Slug
 	channel.Providers = importedChannel.Providers
 
 	log.Printf("Title: %s, Count: %d\n", channel.Name, channel.Providers["youtube"].Subscribers)
@@ -126,6 +128,11 @@ func importChannel(slug string, channelURL *util.URL, dataDir string) {
 	err = util.SaveChannel(channel, dataDir)
 	if err != nil {
 		log.Fatalf("Error saving channel '%s': %v", slug, err)
+	}
+
+	err = util.CreateChannelPage(channel, projectRoot)
+	if err != nil {
+		log.Printf("Unable to create channel page for %s, please create manually.", slug)
 	}
 }
 

--- a/bake/util/channel.go
+++ b/bake/util/channel.go
@@ -354,7 +354,7 @@ func CreateChannelPage(channel *Channel, projectRoot string) error {
 	}
 
 	pageBytes = []byte(strings.Join([]string{"---\n", string(pageBytes), "---"}, ""))
-	log.Printf("Saving file - %s - to folder '%s'.", fileName, dataDir)
+	log.Printf("Saving %s/%s", dataDir, fileName)
 	err = ioutil.WriteFile(path.Join(projectRoot, fmt.Sprintf("/content/%s.md", channel.Slug)), pageBytes, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("Failed to marshal yaml for %s channel page", channel.Slug)

--- a/bake/util/channel.go
+++ b/bake/util/channel.go
@@ -328,7 +328,7 @@ func CreateChannelPage(channel *Channel, projectRoot string) error {
 
 	channelPage := &ChannelPage{
 		Title:      channel.Name,
-		TypeString: "channel",
+		TypeString: "channels",
 		Channel:    channel.Slug,
 		Menu: struct {
 			Main struct {

--- a/bake/util/vidoes.go
+++ b/bake/util/vidoes.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// GetCreatorVideos returns a list of video IDs for a given creator
+func GetCreatorVideos(slug string, projectRoot string) ([]string, error) {
+	// Using "channels" for consistency, but will change to creators in refactor.
+	videoDir, err := ioutil.ReadDir(path.Join(projectRoot, fmt.Sprintf("/data/videos/%s", slug)))
+	if err != nil {
+		return nil, err
+	}
+
+	var videoIds []string
+
+	for _, file := range videoDir {
+		if !file.IsDir() {
+			fileName := file.Name()
+			videoIds = append(videoIds, strings.TrimSuffix(fileName, filepath.Ext(fileName)))
+		}
+	}
+
+	return videoIds, nil
+}


### PR DESCRIPTION
## Description

Part of #171. This is an interim improvement to the `bake` CLI while on-going work is being completed to refactor it. This PR adds a feature to the `import` command so that when a channel is imported, the channel page (in the form of breadtube.tv/channelSlug) is created automatically. 

Additionally, the `permalink` value has been added to the `channelSlug.yml` definition.