### PR TITLE
Homepage Thumbnails

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -3,7 +3,7 @@ title: BreadTube.tv
 type: "channel"
 tags:
 - featured
-videoChannels: false
+videoChannel: true
 videoIframe: false
 videos:
 - 1pTPuoGjQsI

--- a/content/_index.md
+++ b/content/_index.md
@@ -3,8 +3,8 @@ title: BreadTube.tv
 type: "channel"
 tags:
 - featured
-videoChannels: true
-videoIframe: true
+videoChannels: false
+videoIframe: false
 videos:
 - 1pTPuoGjQsI
 - pnmRYRRDbuw

--- a/content/askamortician.md
+++ b/content/askamortician.md
@@ -1,6 +1,6 @@
 ---
 title: Ask A Mortician
-type: channels
+type: channel
 channel: askamortician
 menu:
   main:

--- a/content/blackredguard.md
+++ b/content/blackredguard.md
@@ -1,6 +1,6 @@
 ---
 title: Black Red Guard
-type: channels
+type: channel
 channel: blackredguard
 menu:
   main:

--- a/content/chomskysphilosophy.md
+++ b/content/chomskysphilosophy.md
@@ -1,6 +1,6 @@
 ---
 title: Chomsky's Philosophy
-type: channels
+type: channel
 channel: chomskysphilosophy
 menu:
   main:

--- a/content/gwennofear.md
+++ b/content/gwennofear.md
@@ -1,6 +1,6 @@
 ---
 title: Gwen_No_Fear
-type: channels
+type: channel
 channel: gwennofear
 menu:
   main:

--- a/content/meanstv.md
+++ b/content/meanstv.md
@@ -1,6 +1,6 @@
 ---
 title: MEANS TV
-type: channels
+type: channel
 channel: meanstv
 menu:
   main:

--- a/content/resonanceaudio.md
+++ b/content/resonanceaudio.md
@@ -1,6 +1,6 @@
 ---
 title: Resonance Audio
-type: channels
+type: channel
 channel: resonanceaudio
 menu:
   main:

--- a/content/reyrosho.md
+++ b/content/reyrosho.md
@@ -1,6 +1,6 @@
 ---
 title: ReyRoSho
-type: channels
+type: channel
 channel: reyrosho
 menu:
   main:

--- a/content/shonenronin.md
+++ b/content/shonenronin.md
@@ -1,6 +1,6 @@
 ---
 title: Shonen Ronin
-type: channels
+type: channel
 channel: shonenronin
 menu:
   main:

--- a/content/spacebabies.md
+++ b/content/spacebabies.md
@@ -1,6 +1,6 @@
 ---
 title: Space Babies
-type: channels
+type: channel
 channel: spacebabies
 menu:
   main:

--- a/content/stepbackhistory.md
+++ b/content/stepbackhistory.md
@@ -1,6 +1,6 @@
 ---
 title: Step Back History
-type: channels
+type: channel
 channel: stepbackhistory
 menu:
   main:

--- a/content/stimulator.md
+++ b/content/stimulator.md
@@ -1,6 +1,6 @@
 ---
 title: stimulator
-type: channels
+type: channel
 channel: stimulator
 menu:
   main:

--- a/content/t1j.md
+++ b/content/t1j.md
@@ -1,6 +1,6 @@
 ---
 title: T1J
-type: channels
+type: channel
 channel: t1j
 menu:
   main:

--- a/content/theantifada.md
+++ b/content/theantifada.md
@@ -1,6 +1,6 @@
 ---
 title: The Antifada
-type: channels
+type: channel
 channel: theantifada
 menu:
   main:

--- a/content/thedoubletake.md
+++ b/content/thedoubletake.md
@@ -1,6 +1,6 @@
 ---
 title: The Double Take
-type: channels
+type: channel
 channel: thedoubletake
 menu:
   main:

--- a/content/thegrayzone.md
+++ b/content/thegrayzone.md
@@ -1,6 +1,6 @@
 ---
 title: The Grayzone
-type: channels
+type: channel
 channel: thegrayzone
 menu:
   main:

--- a/content/thejimmydoreshow.md
+++ b/content/thejimmydoreshow.md
@@ -1,6 +1,6 @@
 ---
 title: The Jimmy Dore Show
-type: channels
+type: channel
 channel: thejimmydoreshow
 menu:
   main:

--- a/content/thejuicemedia.md
+++ b/content/thejuicemedia.md
@@ -1,6 +1,6 @@
 ---
 title: The Juice Media
-type: channels
+type: channel
 channel: thejuicemedia
 menu:
   main:

--- a/content/themajorityreport.md
+++ b/content/themajorityreport.md
@@ -1,6 +1,6 @@
 ---
 title: The Majority Report
-type: channels
+type: channel
 channel: themajorityreport
 menu:
   main:

--- a/content/theprogressivevoice.md
+++ b/content/theprogressivevoice.md
@@ -1,6 +1,6 @@
 ---
 title: The Progressive Voice
-type: channels
+type: channel
 channel: theprogressivevoice
 menu:
   main:

--- a/content/thespartacastleague.md
+++ b/content/thespartacastleague.md
@@ -1,6 +1,6 @@
 ---
 title: The Spartacast League
-type: channels
+type: channel
 channel: thespartacastleague
 menu:
   main:

--- a/content/theyoungturks.md
+++ b/content/theyoungturks.md
@@ -1,6 +1,6 @@
 ---
 title: The Young Turks
-type: channels
+type: channel
 channel: theyoungturks
 menu:
   main:

--- a/content/thomavella.md
+++ b/content/thomavella.md
@@ -1,6 +1,6 @@
 ---
 title: Thom Avella
-type: channels
+type: channel
 channel: thomavella
 menu:
   main:

--- a/content/thoughtslime.md
+++ b/content/thoughtslime.md
@@ -1,6 +1,6 @@
 ---
 title: Thought Slime
-type: channels
+type: channel
 channel: thoughtslime
 menu:
   main:

--- a/content/threearrows.md
+++ b/content/threearrows.md
@@ -1,6 +1,6 @@
 ---
 title: Three Arrows
-type: channels
+type: channel
 channel: threearrows
 menu:
   main:

--- a/content/tmbs.md
+++ b/content/tmbs.md
@@ -1,6 +1,6 @@
 ---
 title: The Michael Brooks Show
-type: channels
+type: channel
 channel: tmbs
 menu:
   main:

--- a/content/tmm.md
+++ b/content/tmm.md
@@ -1,6 +1,6 @@
 ---
 title: TMM
-type: channels
+type: channel
 channel: tmm
 menu:
   main:

--- a/content/tomnicholas.md
+++ b/content/tomnicholas.md
@@ -1,6 +1,6 @@
 ---
 title: Tom Nicholas
-type: channels
+type: channel
 channel: tomnicholas
 menu:
   main:

--- a/content/tovarishchendymion.md
+++ b/content/tovarishchendymion.md
@@ -1,6 +1,6 @@
 ---
 title: Tovarishch Endymion
-type: channels
+type: channel
 channel: tovarishchendymion
 menu:
   main:

--- a/content/trashsmash.md
+++ b/content/trashsmash.md
@@ -1,6 +1,6 @@
 ---
 title: Trash Smash
-type: channels
+type: channel
 channel: trashsmash
 menu:
   main:

--- a/content/unicornriot.md
+++ b/content/unicornriot.md
@@ -1,6 +1,6 @@
 ---
 title: Unicorn Riot
-type: channels
+type: channel
 channel: unicornriot
 menu:
   main:

--- a/content/vaush.md
+++ b/content/vaush.md
@@ -1,6 +1,6 @@
 ---
 title: Vaush
-type: channels
+type: channel
 channel: vaush
 menu:
   main:

--- a/content/veggieanarchist.md
+++ b/content/veggieanarchist.md
@@ -1,6 +1,6 @@
 ---
 title: Veggie Anarchist
-type: channels
+type: channel
 channel: veggieanarchist
 menu:
   main:

--- a/content/versobooks.md
+++ b/content/versobooks.md
@@ -1,6 +1,6 @@
 ---
 title: Verso Books
-type: channels
+type: channel
 channel: versobooks
 menu:
   main:

--- a/content/vicberger.md
+++ b/content/vicberger.md
@@ -1,6 +1,6 @@
 ---
 title: Vic Berger
-type: channels
+type: channel
 channel: vicberger
 menu:
   main:

--- a/content/wisecrack.md
+++ b/content/wisecrack.md
@@ -1,6 +1,6 @@
 ---
 title: Wisecrack
-type: channels
+type: channel
 channel: wisecrack
 menu:
   main:

--- a/content/xexizy.md
+++ b/content/xexizy.md
@@ -1,6 +1,6 @@
 ---
 title: Xexizy
-type: channels
+type: channel
 channel: xexizy
 menu:
   main:

--- a/content/yugopnik.md
+++ b/content/yugopnik.md
@@ -1,6 +1,6 @@
 ---
 title: YUGOPNIK
-type: channels
+type: channel
 channel: yugopnik
 menu:
   main:

--- a/content/zeria.md
+++ b/content/zeria.md
@@ -1,6 +1,6 @@
 ---
 title: Zeria
-type: channels
+type: channel
 channel: zeria
 menu:
   main:

--- a/content/zerobooks.md
+++ b/content/zerobooks.md
@@ -1,6 +1,6 @@
 ---
 title: Zero Books
-type: channels
+type: channel
 channel: zerobooks
 menu:
   main:

--- a/data/videos/theserfs/R1lu8-PuMmk.yml
+++ b/data/videos/theserfs/R1lu8-PuMmk.yml
@@ -1,6 +1,6 @@
 id: R1lu8-PuMmk
 title: "WE WON"
 channel: theserfs
-description: "youtube.com/theserfstv is back THANK YOU SO MUCH"
+description: "http://www.youtube.com/theserfstv is back THANK YOU SO MUCH"
 series:
 source: youtube

--- a/data/videos/theserfs/R1lu8-PuMmk.yml
+++ b/data/videos/theserfs/R1lu8-PuMmk.yml
@@ -1,6 +1,6 @@
 id: R1lu8-PuMmk
 title: "WE WON"
 channel: theserfs
-description: "http://www.youtube.com/theserfstv is back THANK YOU SO MUCH"
+description: "youtube.com/theserfstv is back THANK YOU SO MUCH"
 series:
 source: youtube

--- a/layouts/partials/base/head.html
+++ b/layouts/partials/base/head.html
@@ -20,4 +20,4 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
 <link rel="stylesheet" href="/css/breadtube.css" />
-<script src="/js/fuse.js" type="text/javascript"></script>
+<script src="/js/fuse.js"></script>

--- a/layouts/partials/playlists/videos.html
+++ b/layouts/partials/playlists/videos.html
@@ -1,22 +1,22 @@
 {{ $videos := $.Site.Data.videos }}
 {{ $channels := $.Site.Data.channels }}
-{{ $videoChannel := (or (in .Permalink "playlist") (eq true .Params.videoChannels)) }}
+{{ $videoChannel := (or (in .Permalink "playlist") (eq true .Params.videoChannel)) }}
 {{ $videoIframe := (eq true .Params.videoIframe) }}
 
 <ul class="list plain-list">
-  {{ range .Params.videos }}
-    {{ $id := . }}
-    {{ range $channelSlug, $channelVideos := $videos }}
-      {{ range $videoID, $video := $channelVideos }}
-        {{ if eq $id $videoID }}
-          {{ range $channels }}
+  {{- range .Params.videos -}}
+    {{- $id := . -}}
+    {{- range $channelSlug, $channelVideos := $videos -}}
+      {{- range $videoID, $video := $channelVideos -}}
+        {{- if eq $id $videoID -}}
+          {{- range $channels -}}
             {{ $channel := . }}
-            {{ if eq $channel.slug $video.channel }}
+            {{- if eq $channel.slug $video.channel -}}
               {{ partial "videos/card.html" (dict "video" $video "channel" $channel "videoChannel" $videoChannel "videoIframe" $videoIframe) }}
-            {{ end }}
-          {{ end }}
-        {{ end }}
-      {{ end }}
-    {{ end }}
-  {{ end }}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
 </ul>

--- a/layouts/partials/videos/card.html
+++ b/layouts/partials/videos/card.html
@@ -19,7 +19,7 @@
     </div>
     {{ if .videoChannel }}
       <div class="video-metadata">
-        <a href="/{{ .channel.slug }}">
+        <a class="video-channel-link" href="/{{ .channel.slug }}">
           <img alt="{{ .channel.name }}" src="/img/channels/{{ .channel.slug }}.jpg" class="video-channel-image" />
           <span class="video-channel-name">{{ .channel.name }}</span>
         </a>

--- a/layouts/partials/videos/card.html
+++ b/layouts/partials/videos/card.html
@@ -1,46 +1,54 @@
-{{ if .videoIframe }}
-  <li class="channel-video">
-    <ul>
-      <li class="video">
-        <div class="video-item">
-          <iframe class="video-iframe" src="https://www.youtube.com/embed/{{ .video.id }}" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-          {{ partial "channels/card.html" (dict "channel" .channel) }}
-          <div class="video-text">
-            <div class="video-title">
-              {{ .video.title }}
-            </div>
-            <div class="video-description">
-              {{ .video.description | markdownify }}
-            </div>
+{{ if .videoChannel }}
+<li class="channel-video">
+  <ul>
+    {{ partial "channels/card.html" (dict "channel" .channel) }}
+    <li class="video">
+      <div class="video-item">
+        {{ if .videoIframe }}
+        <iframe class="video-iframe" src="https://www.youtube.com/embed/{{ .video.id }}" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        {{ else }}
+        <div class="video-image">
+          <div class="video-imageWrap">
+            <img src="https://i3.ytimg.com/vi/{{ .video.id }}/hqdefault.jpg" alt="{{ .video.title }}" />
           </div>
         </div>
-      </li>
-    </ul>
-  </li>
-{{ else }}
-  <li class="video-item">
-    <div class="video">
-      <div class="video-image">
-        <div class="video-imageWrap">
-          <img src="https://i3.ytimg.com/vi/{{ .video.id }}/hqdefault.jpg" alt="{{ .video.title }}" />
+        {{ end }}
+        <div class="video-text">
+          <div class="video-title">
+            <a class="video-link" href="https://youtu.be/{{ .video.id }}" target="_blank">
+              {{ .video.title }}
+            </a>
+          </div>
+          <div class="video-description">
+            {{ .video.description | markdownify }}
+          </div>
         </div>
       </div>
-      <div class="video-text">
-        <div class="video-title">
-          <a class="video-link" href="https://youtu.be/{{ .video.id }}" target="_blank">
-            {{ .video.title }}
-          </a>
-        </div>
-        <div class="video-description">
-          {{ .video.description }}
-        </div>
-        {{ if .videoChannel }}
-          <div class="video-metadata">
-            <img alt="{{ .channel.name }}" src="/img/channels/{{ .channel.slug }}.jpg" class="video-channel-image" />
-            <span class="video-channel-name">{{ .channel.name }}</span>
-          </div>
-        {{ end }}
+    </li>
+  </ul>
+</li>
+{{ else }}
+<li class="video-item">
+  <div class="video">
+    <div class="video-image">
+      <div class="video-imageWrap">
+        <img src="https://i3.ytimg.com/vi/{{ .video.id }}/hqdefault.jpg" alt="{{ .video.title }}" />
       </div>
     </div>
-  </li>
+    <div class="video-text">
+      <div class="video-title">
+        <a class="video-link" href="https://youtu.be/{{ .video.id }}" target="_blank">
+          {{ .video.title }}
+        </a>
+      </div>
+      <div class="video-description">
+        {{ .video.description }}
+      </div>
+      <div class="video-metadata">
+        <img alt="{{ .channel.name }}" src="/img/channels/{{ .channel.slug }}.jpg" class="video-channel-image" />
+        <span class="video-channel-name">{{ .channel.name }}</span>
+      </div>
+    </div>
+  </div>
+</li>
 {{ end }}

--- a/layouts/partials/videos/card.html
+++ b/layouts/partials/videos/card.html
@@ -15,9 +15,15 @@
         {{ end }}
         <div class="video-text">
           <div class="video-title">
-            <a class="video-link" href="https://youtu.be/{{ .video.id }}" target="_blank">
-              {{ .video.title }}
-            </a>
+            {{ if .videoIframe }}
+              <a href="https://youtu.be/{{ .video.id }}" target="_blank">
+                {{ .video.title }}
+              </a>
+            {{ else }}
+              <a class="video-link" href="https://youtu.be/{{ .video.id }}" target="_blank">
+                {{ .video.title }}
+              </a>
+            {{ end }}
           </div>
           <div class="video-description">
             {{ .video.description | markdownify }}
@@ -43,10 +49,6 @@
       </div>
       <div class="video-description">
         {{ .video.description }}
-      </div>
-      <div class="video-metadata">
-        <img alt="{{ .channel.name }}" src="/img/channels/{{ .channel.slug }}.jpg" class="video-channel-image" />
-        <span class="video-channel-name">{{ .channel.name }}</span>
       </div>
     </div>
   </div>

--- a/layouts/partials/videos/card.html
+++ b/layouts/partials/videos/card.html
@@ -1,28 +1,30 @@
 <li class="video-item">
   <div class="video">
-    <div class="video-image">
-      <div class="video-imageWrap">
-        <img src="https://i3.ytimg.com/vi/{{ .video.id }}/hqdefault.jpg" alt="{{ .video.title }}" />
+    <div class="video-link-container">
+      <div class="video-image">
+        <div class="video-imageWrap">
+          <img src="https://i3.ytimg.com/vi/{{ .video.id }}/hqdefault.jpg" alt="{{ .video.title }}" />
+        </div>
       </div>
-    </div>
-    <div class="video-text">
-      <div class="video-title">
-        <a class="video-link" href="https://youtu.be/{{ .video.id }}" target="_blank">
-          {{ .video.title }}
-        </a>
-      </div>
-      <div class="video-description">
-        {{ .video.description }}
-      </div>
-      {{ if .videoChannel }}
-        <div class="video-metadata">
-          <a href="/{{ .channel.slug }}">
-            <img alt="{{ .channel.name }}" src="/img/channels/{{ .channel.slug }}.jpg" class="video-channel-image" />
-            <span class="video-channel-name">{{ .channel.name }}</span>
+      <div class="video-text">
+        <div class="video-title">
+          <a class="video-link" href="https://youtu.be/{{ .video.id }}" target="_blank">
+            {{ .video.title }}
           </a>
         </div>
-      {{ end }}
+        <div class="video-description">
+          {{ .video.description }}
+        </div>
+      </div>
     </div>
+    {{ if .videoChannel }}
+      <div class="video-metadata">
+        <a href="/{{ .channel.slug }}">
+          <img alt="{{ .channel.name }}" src="/img/channels/{{ .channel.slug }}.jpg" class="video-channel-image" />
+          <span class="video-channel-name">{{ .channel.name }}</span>
+        </a>
+      </div>
+    {{ end }}
   </div>
 </li>
 

--- a/layouts/partials/videos/card.html
+++ b/layouts/partials/videos/card.html
@@ -1,3 +1,23 @@
+{{ if .videoIframe }}
+<li class="channel-video">
+  <ul>
+    <li class="video">
+      <div class="video-item">
+        <iframe class="video-iframe" src="https://www.youtube.com/embed/{{ .video.id }}" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        {{ partial "channels/card.html" (dict "channel" .channel) }}
+        <div class="video-text">
+          <div class="video-title">
+            {{ .video.title }}
+          </div>
+          <div class="video-description">
+            {{ .video.description | markdownify }}
+          </div>
+        </div>
+      </div>
+    </li>
+  </ul>
+</li>
+{{ else }}
 <li class="video-item">
   <div class="video">
     <div class="video-link-container">
@@ -27,13 +47,4 @@
     {{ end }}
   </div>
 </li>
-
-<!-- div id="modal-video-{{ .video.id}}" class="modal modal-video" tabindex="-1" role="dialog">
-  <div class="modal-dialog modal-xl modal-dialog-centered" role="document">
-    <div class="modal-content">
-      <div class="embed-responsive embed-responsive-16by9">
-        <iframe title="{{ .video.title }}" class="embed-responsive-item" src="https://www.youtube.com/embed/{{ .video.id }}" allowfullscreen></iframe>
-      </div>
-    </div>
-  </div>
-</div -->
+{{ end }}

--- a/layouts/partials/videos/card.html
+++ b/layouts/partials/videos/card.html
@@ -1,39 +1,3 @@
-{{ if .videoChannel }}
-<li class="channel-video">
-  <ul>
-    {{ partial "channels/card.html" (dict "channel" .channel) }}
-    <li class="video">
-      <div class="video-item">
-        {{ if .videoIframe }}
-        <iframe class="video-iframe" src="https://www.youtube.com/embed/{{ .video.id }}" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        {{ else }}
-        <div class="video-image">
-          <div class="video-imageWrap">
-            <img src="https://i3.ytimg.com/vi/{{ .video.id }}/hqdefault.jpg" alt="{{ .video.title }}" />
-          </div>
-        </div>
-        {{ end }}
-        <div class="video-text">
-          <div class="video-title">
-            {{ if .videoIframe }}
-              <a href="https://youtu.be/{{ .video.id }}" target="_blank">
-                {{ .video.title }}
-              </a>
-            {{ else }}
-              <a class="video-link" href="https://youtu.be/{{ .video.id }}" target="_blank">
-                {{ .video.title }}
-              </a>
-            {{ end }}
-          </div>
-          <div class="video-description">
-            {{ .video.description | markdownify }}
-          </div>
-        </div>
-      </div>
-    </li>
-  </ul>
-</li>
-{{ else }}
 <li class="video-item">
   <div class="video">
     <div class="video-image">
@@ -50,7 +14,24 @@
       <div class="video-description">
         {{ .video.description }}
       </div>
+      {{ if .videoChannel }}
+        <div class="video-metadata">
+          <a href="/{{ .channel.slug }}">
+            <img alt="{{ .channel.name }}" src="/img/channels/{{ .channel.slug }}.jpg" class="video-channel-image" />
+            <span class="video-channel-name">{{ .channel.name }}</span>
+          </a>
+        </div>
+      {{ end }}
     </div>
   </div>
 </li>
-{{ end }}
+
+<!-- div id="modal-video-{{ .video.id}}" class="modal modal-video" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-xl modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="embed-responsive embed-responsive-16by9">
+        <iframe title="{{ .video.title }}" class="embed-responsive-item" src="https://www.youtube.com/embed/{{ .video.id }}" allowfullscreen></iframe>
+      </div>
+    </div>
+  </div>
+</div -->

--- a/scripts/create_channel_page.sh
+++ b/scripts/create_channel_page.sh
@@ -5,7 +5,7 @@ ls data/channels/ | while read data; do
   if [ ! -e "$page" ]; then
     echo "---
 title: $name
-type: channels
+type: channel
 channel: $slug
 menu:
   main:

--- a/static/css/breadtube.css
+++ b/static/css/breadtube.css
@@ -592,13 +592,13 @@ button, select, input, textarea { font-family: inherit; }
 }
 
 .video-link::after {
-  bottom: 0;
   content: '';
   left: 0;
   position: absolute;
   right: 0;
   top: 0;
   z-index: 5;
+  height: 60%;
 }
 
 .video-metadata {

--- a/static/css/breadtube.css
+++ b/static/css/breadtube.css
@@ -591,14 +591,19 @@ button, select, input, textarea { font-family: inherit; }
   font-size: 1.1rem;
 }
 
+.video-link-container {
+  display: block;
+  position: relative;
+}
+
 .video-link::after {
+  bottom: 0;
   content: '';
   left: 0;
   position: absolute;
   right: 0;
   top: 0;
   z-index: 5;
-  height: 60%;
 }
 
 .video-metadata {

--- a/static/css/breadtube.css
+++ b/static/css/breadtube.css
@@ -608,7 +608,6 @@ button, select, input, textarea { font-family: inherit; }
 
 .video-metadata {
   overflow: hidden;
-  color: #555;
   margin-top: 5px;
 }
 
@@ -622,6 +621,15 @@ button, select, input, textarea { font-family: inherit; }
 .video-metadata .video-channel-name {
   float: left;
   padding-top: 6px;
+  color: #555;
+}
+
+.video-metadata .video-channel-link .video-channel-name:hover {
+  color: #880e7d;
+}
+
+.video-metadata .video-channel-link .video-channel-name {
+  text-decoration: underline;
 }
 
 .content {
@@ -635,7 +643,6 @@ button, select, input, textarea { font-family: inherit; }
 .content img {
   margin-bottom: 1.5rem;
 }
-
 
 .content ul {
   list-style: disc;

--- a/static/css/breadtube.css
+++ b/static/css/breadtube.css
@@ -570,7 +570,7 @@ button, select, input, textarea { font-family: inherit; }
 }
 
 .channel-video .video-text {
-  padding-top: 1rem;
+  padding-top: 0;
   padding-left: 0;
 }
 

--- a/static/css/breadtube.css
+++ b/static/css/breadtube.css
@@ -570,8 +570,7 @@ button, select, input, textarea { font-family: inherit; }
 }
 
 .channel-video .video-text {
-  margin-top: 0;
-  padding-top: 0;
+  padding-top: 1rem;
   padding-left: 0;
 }
 


### PR DESCRIPTION
https://deploy-preview-226--breadtubetv.netlify.com/

This is what's happening when our homepage loads iFrames from YouTube.

This PR resolves the videos as Thumbnails instead of iFrames.

It also turns the channel name into a link across the site.

![Screen Shot 2019-04-25 at 5 34 43 PM](https://user-images.githubusercontent.com/81055/56726034-95e81300-6780-11e9-9901-d12f0d5c190c.jpg)