### PR TITLE
fixed responsive video card

### DIFF
--- a/static/css/breadtube.css
+++ b/static/css/breadtube.css
@@ -502,7 +502,7 @@ button, select, input, textarea { font-family: inherit; }
 }
 
 /* Videos */
-.video {
+.video-link-container {
   align-items: flex-start;
   display: flex;
   height: 100%;
@@ -510,8 +510,9 @@ button, select, input, textarea { font-family: inherit; }
 }
 
 @media (min-width: 768px) {
-  .video {
+  .video-link-container {
     display: block;
+    position: relative;
   }
 }
 
@@ -591,11 +592,6 @@ button, select, input, textarea { font-family: inherit; }
   font-size: 1.1rem;
 }
 
-.video-link-container {
-  display: block;
-  position: relative;
-}
-
 .video-link::after {
   bottom: 0;
   content: '';
@@ -609,6 +605,13 @@ button, select, input, textarea { font-family: inherit; }
 .video-metadata {
   overflow: hidden;
   margin-top: 5px;
+  margin-left: 5.7rem;
+}
+
+@media (min-width: 768px) {
+  .video-metadata {
+    margin-left: 0;
+  }
 }
 
 .video-metadata .video-channel-image {


### PR DESCRIPTION
https://deploy-preview-227--breadtubetv.netlify.com/

Moved the flex component to the video link container.

The previous refactor allows us to link to the video and the title, but the addition of another object broke the flex model.

Small UI issue in that a short description puts unnecessary whitespace before the channel (first video vs the rest)

<img width="487" alt="Screen Shot 2019-04-25 at 6 40 57 PM" src="https://user-images.githubusercontent.com/81055/56730140-b23c7d80-6789-11e9-9450-ec9ab94927a7.png">
