### PR TITLE
remove email from forms

### DIFF
--- a/layouts/partials/channels/new.html
+++ b/layouts/partials/channels/new.html
@@ -22,4 +22,8 @@
     <div data-netlify-recaptcha="true"></div>
   </div>
   <button type="submit" class="button is-primary">Send Channel</button>
+  <p>
+    <br>
+    <em>Submissions are sent to our <a href="https://breadtube.tv/discord">Discord server</a>, come join us!</em>
+  </p>
 </form>

--- a/layouts/partials/channels/new.html
+++ b/layouts/partials/channels/new.html
@@ -19,13 +19,6 @@
     <textarea class="field-input is-textarea" class="form-control" id="videoUrl" rows="6" cols="50" name="VIDEO_URLS"></textarea>
   </div>
   <div class="field">
-    <label class="field-label" for="submitterEmail">
-      Your Email Address
-      <span class="visually-hidden">(</span><small class="field-hint">We'll use this solely to keep you informed of this addition.</small><span class="visually-hidden">)</span>
-    </label>
-    <input class="field-input" id="submitterEmail" type="email" name="SUBMITTER_EMAIL" placeholder="Enter email"/>
-  </div>
-  <div class="field">
     <div data-netlify-recaptcha="true"></div>
   </div>
   <button type="submit" class="button is-primary">Send Channel</button>

--- a/layouts/partials/playlists/new.html
+++ b/layouts/partials/playlists/new.html
@@ -18,4 +18,8 @@
     <div data-netlify-recaptcha="true"></div>
   </div>
   <button type="submit" class="button is-primary">Send Playlist</button>
+  <p>
+    <br>
+    <em>Submissions are sent to our <a href="https://breadtube.tv/discord">Discord server</a>, come join us!</em>
+  </p>
 </form>

--- a/layouts/partials/playlists/new.html
+++ b/layouts/partials/playlists/new.html
@@ -15,13 +15,6 @@
     <textarea class="field-input is-textarea" class="form-control" id="videoUrl" rows="4" cols="50" name="VIDEO_URLS" required></textarea>
   </div>
   <div class="field">
-    <label class="field-label" for="submitterEmail">
-      Your Email Address
-      <span class="visually-hidden">(</span><small class="field-hint">We'll use this solely to keep you informed of this addition.</small><span class="visually-hidden">)</span>
-    </label>
-    <input class="field-input"  id="submitterEmail" type="email" name="SUBMITTER_EMAIL" placeholder="Enter email"/>
-  </div>
-  <div class="field">
     <div data-netlify-recaptcha="true"></div>
   </div>
   <button type="submit" class="button is-primary">Send Playlist</button>


### PR DESCRIPTION
Content suggestions are going to hit Discord directly, no need to have email anymore, in fact it's a security floor.

Todo in a further PR

- Thank you page
  - Linking to discord
  - Linking to Github
  - Showing video of how to add yourself

![Screen Shot 2019-04-26 at 12 24 24 PM](https://user-images.githubusercontent.com/81055/56783416-40fada00-681e-11e9-8199-70a02adc1f5f.png)
