### PR TITLE
Videos Navigation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,13 +19,13 @@ url = "/channels/"
 weight = 2
 
 [[ menu.main ]]
-name = "Playlists"
-url = "/playlists/"
+name = "Videos"
+url = "/videos/"
 weight = 3
 
 [[ menu.main ]]
-name = "Blog"
-url = "/blog/"
+name = "Playlists"
+url = "/playlists/"
 weight = 4
 
 [[ menu.footer ]]

--- a/content/videos/_index.md
+++ b/content/videos/_index.md
@@ -1,0 +1,5 @@
+---
+title: BreadTube.tv
+type: "videos"
+tags: []
+---

--- a/layouts/partials/base/footer.html
+++ b/layouts/partials/base/footer.html
@@ -10,5 +10,9 @@
     </li>
     {{- end }}
   </ul>
-  <p><a href="/privacy/">Privacy Policy</a></p>
+
+  <ul class="footer-list plain-list">
+    <li><a href="/blog/">Blog</a></li>
+    <li><a href="/privacy/">Privacy Policy</a></li>
+  </ul>
 </footer>

--- a/layouts/videos/list.html
+++ b/layouts/videos/list.html
@@ -1,0 +1,16 @@
+{{ define "main" }}
+  {{ $videos := $.Site.Data.videos }}
+  {{ $channels := $.Site.Data.channels }}
+  <ul class="list plain-list">
+    {{- range $channelSlug, $channelVideos := $videos -}}
+      {{- range $videoID, $video := $channelVideos -}}
+        {{- range $channel := $channels -}}
+          {{ $channel := . }}
+          {{ if eq $channel.slug $video.channel }}
+            {{ partial "videos/card.html" (dict "video" $video "channel" $channel "videoChannel" true "videoIframe" false) }}
+          {{ end }}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  </ul>
+{{ end }}


### PR DESCRIPTION
Shows the videos on their own page, makes the navigation completely content related. Gives us the pages necessary to add video search and suggest features in the future.

https://deploy-preview-241--breadtubetv.netlify.com/videos/

Sort order is based on channel name presently, if we were able to get the video created dates through the bake command we could sort most recent first.

<img width="1091" alt="Screen Shot 2019-04-27 at 7 04 00 PM" src="https://user-images.githubusercontent.com/81055/56848765-3ffda180-691f-11e9-854a-7580835c89fd.png">
<img width="316" alt="Screen Shot 2019-04-27 at 7 04 05 PM" src="https://user-images.githubusercontent.com/81055/56848766-42f89200-691f-11e9-9960-9051c586391a.png">