### PR TITLE
Github Settings

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,95 @@
+repository:
+  # See https://developer.github.com/v3/repos/#edit for all available settings.
+
+  # The name of the repository. Changing this will rename the repository
+  name: breadtubetv
+  # A short description of the repository that will show up on GitHub
+  description: Quality content going against the prevailing winds of the internet.
+  # A URL with more information about the repository
+  homepage: https://breadtube.tv
+  # Either `true` to make the repository private, or `false` to make it public.
+  private: false
+  # Either `true` to enable issues for this repository, `false` to disable them.
+  has_issues: true
+  # Either `true` to enable the wiki for this repository, `false` to disable it.
+  has_wiki: true
+  # Either `true` to enable downloads for this repository, `false` to disable them.
+  has_downloads: true
+  # Updates the default branch for this repository.
+  default_branch: master
+  # Either `true` to allow squash-merging pull requests, or `false` to prevent
+  # squash-merging.
+  allow_squash_merge: true
+  # Either `true` to allow merging pull requests with a merge commit, or `false`
+  # to prevent merging pull requests with merge commits.
+  allow_merge_commit: true
+  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
+  # rebase-merging.
+  allow_rebase_merge: true
+
+# TODO Labels: define labels for Issues and Pull Requests
+labels:
+
+# Collaborators: give specific users access to this repository.
+collaborators:
+    # Note: Only valid on organization-owned repositories.
+    # The permission to grant the collaborator. Can be one of:
+    # * `pull` - can pull, but not push to or administer this repository.
+    # * `push` - can pull and push, but not administer this repository.
+    # * `admin` - can pull, push and administer this repository.
+  - username: craiglonsdale
+    permission: admin
+  - username: dirkkelly
+    permission: admin
+  - username: j16r
+    permission: admin
+  - username: jaymickey
+    permission: admin
+  - username: jordanmaguire
+    permission: push
+  - username: murodese
+    permission: push
+  - username: ozzyaaron
+    permission: push
+  - username: pkunkypoos
+    permission: push
+  - username: selwun
+    permission: push
+  - username: soliveira-vouga
+    permission: push
+  - username: stjn
+    permission: push
+  - username: stephaniewillhide
+    permission: push
+  - username: thursenfuerst
+    permission: push
+
+branches:
+  - name: master
+    # https://developer.github.com/v3/repos/branches/#update-branch-protection
+    # Branch Protection settings. Set to null to disable
+    protection:
+      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
+      required_pull_request_reviews:
+        # The number of approvals required. (1-6)
+        required_approving_review_count: 1
+        # Dismiss approved reviews automatically when a new commit is pushed.
+        dismiss_stale_reviews: false
+        # Blocks merge until code owners have reviewed.
+        require_code_owner_reviews: true
+        # Specify which users and teams can dismiss pull request reviews. Pass an empty dismissal_restrictions object to disable. User and team dismissal_restrictions are only available for organization-owned repositories. Omit this parameter for personal repositories.
+        dismissal_restrictions:
+          users: []
+          teams: []
+      # Required. Require status checks to pass before merging. Set to null to disable
+      required_status_checks:
+        # Required. Require branches to be up to date before merging.
+        strict: true
+        # Required. The list of status checks to require in order to merge into this branch
+        contexts: []
+      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+      enforce_admins: true
+      # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
+      restrictions:
+        users: []
+        teams: []

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -28,7 +28,6 @@ repository:
   allow_rebase_merge: true
 
 # TODO Labels: define labels for Issues and Pull Requests
-labels:
 
 # Collaborators: give specific users access to this repository.
 collaborators:


### PR DESCRIPTION
Set GitHub configuration from the settings file, allows for democratic decision making around vital configuration.

Once we have this in I would like to discuss whether we can [allow admins to merge without a review](https://github.com/breadtubetv/breadtubetv/compare/github-settings?expand=1#diff-f4a8cbb8ecd8c5ca594e8e75183845e1R90) related to #147.

Current state of the project is very dependent on manual work of developers, including in the pull request process.

- There are now notifications in Discord of submissions and pull requests
- There is a pull request #200 to update content that is now 9 days old
- Videos are being included in submission which gives context
- There is now a link to r/BreadTube #247 search results for each submission

We still need to complete documentation, but the process is outlined in #248 

[Link to Chart](https://deploy-preview-248--breadtubetv.netlify.com/about/)
<img width="357" alt="Screen Shot 2019-04-28 at 1 21 49 PM" src="https://user-images.githubusercontent.com/81055/56859104-cf0ac800-69b8-11e9-8555-061dfeb905b6.png">
