### PR TITLE
reddit link uses title:name OR flair:name

### DIFF
--- a/layouts/channel/single.html
+++ b/layouts/channel/single.html
@@ -14,7 +14,7 @@
     <div class="heading-meta">
       <ul class="plain-list">
         <li>
-          <a href="https://www.reddit.com/r/BreadTube/search?q={{ $channel.name | lower }}&restrict_sr=1" target="_blank"><strong>r/BreadTube</strong></a>
+          <a href="https://www.reddit.com/r/BreadTube/search?q=title:{{ $channel.name | lower }} OR flair:{{ $channel.name | lower }}&restrict_sr=1" target="_blank"><strong>r/BreadTube</strong></a>
         </li>
         {{- range $provider, $data := $channel.providers -}}
           <li>


### PR DESCRIPTION
Via Discord

```
asdfjasdjkflToday at 7:24 PM
hey folks. Usually when I look up a channel on /r/breadtube I search for
title:channel+name OR flair:channel+name
because when the channel name isn't in the title it's usually in the flair
I was wondering if y'all want to change the r/breadtube link on channel pages to something like that
```