### PR TITLE
fix url changing

### DIFF
--- a/layouts/partials/search/code.html
+++ b/layouts/partials/search/code.html
@@ -43,7 +43,7 @@ function listSearch(query) {
     search.value = query.replace("%20"," ");
   }
 
-  window.location.hash = 'search:' + query.toLowerCase();;
+  history.replaceState(window.history.state,{},'#search:' + query.toLowerCase());
   var results = fuse.search(query);
 
   for (var i = 0; i < lists.length; i++) {


### PR DESCRIPTION
Fixes the url getting every letter of the search

## Reproduce

- Visit https://breadtube.tv/channels
- Search for `contrapo`
- Click `back`
- You should be on https://breadtube.tv/channels/#search:contrap
- click `Contrapoints`
- Click `back`
- You should be on https://breadtube.tv/channels/#search:contrap
- Click `back`
- You should be on https://breadtube.tv/channels/#search:contra

## Acceptance

- Visit https://deploy-preview-279--breadtubetv.netlify.com/channels
- Search for `contrapo`
- You should be on `null`
- Click `forward`
- You should be on https://deploy-preview-279--breadtubetv.netlify.com/channels
- Search for `contrapo`
- Click `Contrapoints`
- Click `back`
- You should be on https://deploy-preview-279--breadtubetv.netlify.com/channels/#search:contrap
- Click `back`
- You should be on `null`