### PR TITLE
Permissions Change: Admins Merge on data and content

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -87,7 +87,8 @@ branches:
         # Required. The list of status checks to require in order to merge into this branch
         contexts: []
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
-      enforce_admins: true
+      enforce_admins: false
+        # BreadTube: Admins can only merge for data/* and content/* changes, 24 hours after pull request, changes must not affect data structure.
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
       restrictions:
         users: []


### PR DESCRIPTION
Currently all changes to the website require a review from at least one other person before being deployed. The change to this policy has been an open discussion since the #147 where a merge was forced through in order to support The Serfs during their time of being censored by Google.

Now that we have fully working scripts for downloading content I think we should move into a phase of rapid content changes to the site to allow for usage of the website in distribution, eg: tweeting a link to a breadtube channel page. This sort of functionality will be useful for a proof to concept to the community of the potentials for a website using this open source platform to monitor content in an "automated" way.

This is a request for change to permissions to allow admin merging without a review from anyone under certain committed conditions:

> Admins can only merge for data/* and content/* changes, 24 hours after pull request, changes must not affect data structure.

Now that all changes are pushed to discord we have a way for all users to see the change requests and merges. We can use the revert feature in situations where there is conflict over whether the content should be merged.

I'd also happily discuss the restriction of not allowing new channels to be posted, this would fast track the regular updates and allow us to post videos on known channels without a review.

The goal would be to fully automate this process and eventually remove the review time restriction all together, allowing the website to respond in real time to content changes suggested via bots.

Feedback and discussion on this welcomed.

Thanks