### PR TITLE
Use param url instead of Hash

### DIFF
--- a/layouts/channel/single.html
+++ b/layouts/channel/single.html
@@ -26,7 +26,7 @@
       <div class="tags">
       {{ range $channel.tags }}
         {{ if not (eq . "breadtube") }}
-          <a href="/channels/#search:{{ . | lower }}" class="tag">{{ . }}</a>
+          <a href="/channels/?q={{ . | lower }}" class="tag">{{ . }}</a>
         {{ end }}
       {{ end }}
     </div>

--- a/layouts/partials/search/code.html
+++ b/layouts/partials/search/code.html
@@ -43,7 +43,7 @@ function listSearch(query) {
     search.value = query.replace("%20"," ");
   }
 
-  history.replaceState(window.history.state,{},'#search:' + query.toLowerCase());
+  history.replaceState(window.history.state,{},'?q=' + encodeURIComponent(query.toLowerCase()));
   var results = fuse.search(query);
 
   for (var i = 0; i < lists.length; i++) {
@@ -70,11 +70,17 @@ for (var i = 0; i < navlinks.length; i++) {
   var link = navlinks[i];
   link.addEventListener("click", function(event) {
     event.preventDefault();
-    window.location = event.target.href + location.hash;
+    window.location = event.target.href + location.search;
   });
 }
 
-if(window.location.hash && window.location.hash.indexOf('search') > -1) {
-  listSearch(window.location.hash.replace("#search:",""));
+/* Execute search on page load */
+var urlValue = window.location.search.replace("?q=","");
+var hashUrlValue = window.location.hash.replace("#search:","");
+
+if(urlValue) {
+  listSearch(decodeURIComponent(urlValue));
+} else if(hashUrlValue) {
+  listSearch(decodeURIComponent(hashUrlValue));
 }
 </script>


### PR DESCRIPTION
Search updated to use a query param instead of a hash, allows tags on index (in upcoming pr) to reload the page content, continues support of old hash urls

https://deploy-preview-285--breadtubetv.netlify.com/channels?q=contrapoints
https://deploy-preview-285--breadtubetv.netlify.com/channels#search:contrapoints [deprecated]