### PR TITLE
Fix GitHub organization link in Privacy Policy

### DIFF
--- a/content/privacy/_index.md
+++ b/content/privacy/_index.md
@@ -2,7 +2,7 @@
 title: BreadTube Privacy Policy
 ---
 
-The https://github.com/breadtube community operates https://BreadTube.tv, which provides listings of content creators.
+The https://github.com/breadtubetv community operates https://BreadTube.tv, which provides listings of content creators.
 
 This page is used to inform website visitors regarding our policies with the collection, use, and disclosure of Personal Information if anyone decided to use https://BreadTube.tv.
 


### PR DESCRIPTION
Minor fix. But what’s actually up with the https://github.com/breadtube org, was it just a typo and always owned by someone else?