### PR TITLE
Short Video Cards

### DIFF
--- a/layouts/partials/videos/card.html
+++ b/layouts/partials/videos/card.html
@@ -40,7 +40,7 @@
           </a>
         </div>
         <div class="video-description">
-          {{ (substr (.video.description | replaceRE "https?://([^ ]+)" "") 0 140) }}
+          {{ .video.description | replaceRE "https?://([^ ]+)" "" | truncate 140) }}
         </div>
       </div>
     </div>

--- a/layouts/partials/videos/card.html
+++ b/layouts/partials/videos/card.html
@@ -10,7 +10,7 @@
             {{ .video.title }}
           </div>
           <div class="video-description">
-            {{ (substr (.video.description | replaceRE "https?://([^ ]+)" "") 0 140) }}
+            {{ .video.description | replaceRE "https?://([^ ]+)" "" | truncate 140 }}
           </div>
         </div>
       </div>

--- a/layouts/partials/videos/card.html
+++ b/layouts/partials/videos/card.html
@@ -10,7 +10,7 @@
             {{ .video.title }}
           </div>
           <div class="video-description">
-            {{ .video.description | markdownify }}
+            {{ (substr (.video.description | replaceRE "https?://([^ ]+)" "") 0 140) }}
           </div>
         </div>
       </div>
@@ -40,7 +40,7 @@
           </a>
         </div>
         <div class="video-description">
-          {{ .video.description }}
+          {{ (substr (.video.description | replaceRE "https?://([^ ]+)" "") 0 140) }}
         </div>
       </div>
     </div>

--- a/layouts/partials/videos/card.html
+++ b/layouts/partials/videos/card.html
@@ -40,7 +40,7 @@
           </a>
         </div>
         <div class="video-description">
-          {{ .video.description | replaceRE "https?://([^ ]+)" "" | truncate 140) }}
+          {{ .video.description | replaceRE "https?://([^ ]+)" "" | truncate 140 }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Shortens all video cards and removes the need to manually edit the description.

This is a quick hack, would like a more comprehensive solution. It's also embedded in a few of the recent content updates, but wanted to call it out in this PR.